### PR TITLE
🧹 Janitor: Refactor section parsing and fix typos in block.go

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,13 @@
+## 2026-01-27 - Refactor section parsing and fix typos in block.go
+
+### Issue
+`SectionAsRenderBlock` has repetitive integer parsing logic and typo in error messages.
+
+### Root Cause
+Copy-paste coding for `size_x` and `size_y` parsing, and lack of spell check.
+
+### Solution
+Introduced `getInt` helper function and corrected "cant" to "can't".
+
+### Pattern
+Refactoring repetitive parsing logic.

--- a/block.go
+++ b/block.go
@@ -27,28 +27,33 @@ type LabelBlock struct {
 	background_color *template.Template
 }
 
+func getInt(section gocfg.SectionProvider, key string, defaultVal int) (int, error) {
+	if !section.RawHasKey(key) {
+		return defaultVal, nil
+	}
+	r, err := strconv.Atoi(section.RawGet(key))
+	if err != nil {
+		return 0, fmt.Errorf("while getting %s: %w", key, err)
+	}
+	return r, nil
+}
+
 func SectionAsRenderBlock(section gocfg.SectionProvider) (RenderableBlock, error) {
-	size_x := 1
-	size_y := 1
-	if section.RawHasKey("size_x") {
-		r, err := strconv.Atoi(section.RawGet("size_x"))
-		if err != nil {
-			return nil, fmt.Errorf("while getting size_x: %w", err)
-		}
-		size_x = r
+	size_x, err := getInt(section, "size_x", 1)
+	if err != nil {
+		return nil, err
 	}
-	if section.RawHasKey("size_y") {
-		r, err := strconv.Atoi(section.RawGet("size_y"))
-		if err != nil {
-			return nil, fmt.Errorf("while getting size_y: %w", err)
-		}
-		size_y = r
+
+	size_y, err := getInt(section, "size_y", 1)
+	if err != nil {
+		return nil, err
 	}
+
 	if section.RawHasKey("background_image") && section.RawHasKey("background_color") {
-		return nil, fmt.Errorf("a section cant have both a background_image and a background_color")
+		return nil, fmt.Errorf("a section can't have both a background_image and a background_color")
 	}
 	if section.RawHasKey("background_image") && section.RawHasKey("label") {
-		return nil, fmt.Errorf("a section cant have both a background_image and a label")
+		return nil, fmt.Errorf("a section can't have both a background_image and a label")
 	}
 	if section.RawHasKey("background_image") {
 		tpl, err := template.New("background_image").Parse(section.RawGet("background_image"))


### PR DESCRIPTION
## What Changed
- Added `getInt` helper function in `block.go`.
- Refactored `SectionAsRenderBlock` to use `getInt` for parsing `size_x` and `size_y`.
- Fixed typos "cant" to "can't" in error messages.
- Created `.jules/janitor.md` with a journal entry.
- Created `.jules/CONSISTENTLY_IGNORED.md`.

## Why This Helps
- Reduces code duplication and complexity in `SectionAsRenderBlock`.
- Improves clarity of error messages.
- Establishes the required Janitor journal.

## Before/After
**Before:**
- Repetitive `strconv.Atoi` blocks.
- "cant" in error messages.

**After:**
- Single `getInt` helper usage.
- "can't" in error messages.

## Verification
- Ran `mise exec -- go vet ./...`.
- Ran `mise exec -- go build ./...`.
- Manually verified code changes.

---
*PR created automatically by Jules for task [6900662269697972399](https://jules.google.com/task/6900662269697972399) started by @lucasew*