### PR TITLE
🧹 Janitor: Fix copy-paste error in background_color template parsing

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2025-02-23: Check copy-pasted error messages for variable name mismatches.

--- a/block.go
+++ b/block.go
@@ -88,7 +88,7 @@ func createLabelBlock(section gocfg.SectionProvider, sx, sy int) (RenderableBloc
 	}
 	tpl_color, err := template.New("bg_color").Parse(section.RawGet("background_color"))
 	if err != nil {
-		return nil, fmt.Errorf("invalid label template: %w", err)
+		return nil, fmt.Errorf("invalid background_color template: %w", err)
 	}
 	return LabelBlock{
 		sx: sx, sy: sy,

--- a/block_test.go
+++ b/block_test.go
@@ -114,3 +114,16 @@ func TestSectionAsRenderBlock_Errors(t *testing.T) {
 		t.Error("Expected error for invalid size_x")
 	}
 }
+
+func TestSectionAsRenderBlock_InvalidBackgroundColor(t *testing.T) {
+	section := MockSectionProvider{
+		"label":            "L",
+		"background_color": "{{",
+	}
+	_, err := SectionAsRenderBlock(section)
+	if err == nil {
+		t.Error("Expected error for invalid background_color template")
+	} else if !strings.Contains(err.Error(), "invalid background_color template") {
+		t.Errorf("Expected error message to contain 'invalid background_color template', got '%s'", err.Error())
+	}
+}


### PR DESCRIPTION
This PR fixes a copy-paste error in `block.go` where the error message for invalid `background_color` template parsing incorrectly referred to `label template`.

Changes:
- Corrected error message in `createLabelBlock` to say `invalid background_color template`.
- Added a regression test `TestSectionAsRenderBlock_InvalidBackgroundColor` in `block_test.go` to verify the correct error message.
- Updated `.jules/janitor.md` with the journal entry.

Verification:
- Ran `mise run test` (passed).
- Ran `mise run lint` (passed).

---
*PR created automatically by Jules for task [13078113109873314556](https://jules.google.com/task/13078113109873314556) started by @lucasew*